### PR TITLE
[PT-332]Добавляем client-info в extra, разделяем парсинг для тестовог…

### DIFF
--- a/lib/omniauth/strategies/sberbusiness.rb
+++ b/lib/omniauth/strategies/sberbusiness.rb
@@ -84,6 +84,7 @@ module OmniAuth
         #  SBBOL промышленный стенд возвращает Json
         @raw_info ||= begin
           result = access_token.get(options.client_options['user_info_path'], headers: info_headers).body
+          #TODO Переделать проверку
           if access_token.client.options[:authorize_url].include? 'edupir.testsbi.sberbank.ru:9443'
             decoded_data = result.split('.').map { |code| decrypt(code) rescue {} }
             decoded_data.reduce(:merge)


### PR DESCRIPTION
По какой-то причине отличается result возвращаемый с тестового стенда sbbol(https://edupir.testsbi.sberbank.ru:9443)
result для тестового:
![Screenshot from 2022-01-13 10-35-43](https://user-images.githubusercontent.com/93449157/149292196-94820cdd-fc2e-4739-88c6-a4ca1ab154ff.png)
И result для промышленного sbbol(https://sbi.sberbank.ru:9443)
result для промышленного:
![Screenshot from 2022-01-13 10-10-55](https://user-images.githubusercontent.com/93449157/149293027-c27381b4-8ff1-4911-a574-e75a53446521.png)
Client_info было вынесено в extra для дальнейшей работы.