### PR TITLE
[PT-332]Убираем парсинг json'а для client_info

### DIFF
--- a/lib/omniauth/strategies/sberbusiness.rb
+++ b/lib/omniauth/strategies/sberbusiness.rb
@@ -75,7 +75,7 @@ module OmniAuth
       def client_info
         access_token.options[:mode] = :header
         client_info_path = options.client_options['client_info_path']
-        JSON.parse(access_token.get(client_info_path, headers: info_headers).body.force_encoding('UTF-8'))
+        access_token.get(client_info_path, headers: info_headers).body.force_encoding('UTF-8')
       end
 
       def raw_info


### PR DESCRIPTION
На прод в логи приходит пустой client_info. Проверяем, возможно, данные пришли не в формате json.